### PR TITLE
change css files paths .

### DIFF
--- a/static/js/hooks.js
+++ b/static/js/hooks.js
@@ -4,8 +4,8 @@ exports.aceEditorCSS = function(){
 };
 
 exports.eejsBlock_styles = function (hook_name, args, cb) {
-  args.content = args.content + "\n<link href='/static/plugins/ep_cristo_tools/static/font-awesome/css/font-awesome.min.css' rel='stylesheet'>";
-  args.content = args.content + "\n<link href='/static/plugins/ep_cristo_tools/static/css/cristo.css' rel='stylesheet'>";
+  args.content = args.content + "\n<link href='../static/plugins/ep_cristo_tools/static/font-awesome/css/font-awesome.min.css' rel='stylesheet'>";
+  args.content = args.content + "\n<link href='../static/plugins/ep_cristo_tools/static/css/cristo.css' rel='stylesheet'>";
 
   return cb();
 };

--- a/templates/clientsScript.ejs
+++ b/templates/clientsScript.ejs
@@ -1,3 +1,3 @@
-<script src="/static/plugins/ep_cristo_tools/static/libs/underscore-min.js"></script>
-<script src="/static/plugins/ep_cristo_tools/static/libs/jquery-1.11.1.min.js"></script>
-<script src="/static/plugins/ep_cristo_tools/static/js/helpers.js"></script>
+<script src="../static/plugins/ep_cristo_tools/static/libs/underscore-min.js"></script>
+<script src="../static/plugins/ep_cristo_tools/static/libs/jquery-1.11.1.min.js"></script>
+<script src="../static/plugins/ep_cristo_tools/static/js/helpers.js"></script>


### PR DESCRIPTION
I found a bug in some css files paths.
When Etherpad runs  under a reverse proxy and under a directry,
   for examles:  https://foo.bar/ether/ -> http://localhost:9001/
Etherpad cannot find some css files, because their path is absolute.
Maybe Etherpad runs in relative paths.

